### PR TITLE
Agent did not honour user provided hostname

### DIFF
--- a/src/main/java/org/am/rmi/firewall/FirewallFriendlyAgent.java
+++ b/src/main/java/org/am/rmi/firewall/FirewallFriendlyAgent.java
@@ -65,8 +65,13 @@ public class FirewallFriendlyAgent {
 		// The port for the RMI registry is specified in the second part
 		// of the URL, in "rmi://"+hostname+":"+port
 
-		final String hostname = InetAddress.getLocalHost().getHostName();
-
+		String userProvidedHostname = System.getProperty("java.rmi.server.hostname");
+		String hostname = null;
+		if (userProvidedHostname == null || "".equals(userProvidedHostname)){
+			hostname = InetAddress.getLocalHost().getHostName();
+		} else {
+			hostname = userProvidedHostname;
+		}
 		System.out.println(PREFIX + "Create an RMI connector server. Url for access: " + getServiceUrl(port, hostname));
 		JMXServiceURL url = new JMXServiceURL(getServiceUrl(port, hostname));
 


### PR DESCRIPTION
FirewallFriendlyAgent did not honour the user-provided hostname (via -Djava.rmi.server.hostname=...).
This PR falls back to the previous behaviour when no hostname is specified. 